### PR TITLE
Fixes plugin integration

### DIFF
--- a/patches.js
+++ b/patches.js
@@ -1,7 +1,7 @@
 
 module.exports = {
   import: `import { createLogger } from 'redux-logger'`,
-  ramda: `import R from 'Ramda'`, // currently not used
+  ramda: `import R from 'Ramda'`, 
   middleware: `  /* ------------- Logger Middleware ------------- */
 
   // remove common noise

--- a/patches.js
+++ b/patches.js
@@ -1,6 +1,6 @@
 
 module.exports = {
-  import: `import createLogger from 'redux-logger'`,
+  import: `import { createLogger } from 'redux-logger'`,
   ramda: `import R from 'Ramda'`, // currently not used
   middleware: `  /* ------------- Logger Middleware ------------- */
 

--- a/plugin.js
+++ b/plugin.js
@@ -20,6 +20,12 @@ const add = async function (context) {
     insert: patches.import,
     after: `from 'redux'`
   })
+  
+  // import in CreateStore file - import R from 'ramda'
+  await ignite.patchInFile(`${APP_PATH}/App/Redux/CreateStore.js`, {
+    insert: patches.ramda,
+    after: `from 'redux'`
+  })
 
   // insert logger middleware right above assemble middleware
   await ignite.patchInFile(`${APP_PATH}/App/Redux/CreateStore.js`, {


### PR DESCRIPTION
This updates the redux-logger import to fix the breaking change caused by v3.0
It also adds ramda back in, because it is indeed used in the middleware